### PR TITLE
Update script to delete previous file before copying new plist

### DIFF
--- a/scripts/install.js
+++ b/scripts/install.js
@@ -6,5 +6,8 @@ const files = [
 ];
 
 files.forEach(file => {
-    fs.createReadStream(file).pipe(fs.createWriteStream(file.replace(EXAMPLE_IDENTIFIER, '')));
+    const newFile = file.replace(EXAMPLE_IDENTIFIER, '');
+    fs.unlink(newFile, () => {
+        fs.createReadStream(file).pipe(fs.createWriteStream(newFile));
+    });
 });


### PR DESCRIPTION
Fixes a problem when updating where old plist would not be overwritten