### PR TITLE
Add support for Bitbucket Pipelines and simple caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 info.plist
 .DS_Store
+/.idea

--- a/README.md
+++ b/README.md
@@ -92,5 +92,10 @@ Displays all the bookmarks you made with all the repos options :
 - ☑️ : The pull request has x tasks to be resolved.
 - 💬 : The pull request has x comments.
 
+### Pipelines
+
+- ✅ : The pipeline ran successfully.
+- ❌ : The pipeline failed.
+
 # License
 MIT © [Nicolas Boisvert](https://nboisvert.com)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ When installing `alfred-bitbucket`, an `alfred-bitbucket/info.plist` file is cre
 
 ### Register environment variables
 
-Since 1.0.3, `info.plist` file is git ignored and copied on installation from an example file. But keep ensuring that you don't push any personnal information.
+Since 1.0.3, `info.plist` file is git ignored and copied on installation from an example file. But keep ensuring that you don't push any personal information.
 
 You can add the required keys either through Alfred `or` directly through the `plist` file.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ You can add the required keys either through Alfred `or` directly through the `p
 5. Fill the values
     - `clientId` : Consumer Key
     - `secret` : Consumer secret
+    - `repoMaxAge`: Number of minutes list of repositories should be cached, defaults to 480
+    - `userMaxAge`: Number of minutes user information should be cached, defaults to 720
+    - `teamMaxAge`: Number of minutes list of teams should be cached, defaults to 720
 6. Save
 
 #### Through the `plist` file.
@@ -53,6 +56,9 @@ You can add the required keys either through Alfred `or` directly through the `p
 3. Fill the following values.
     - `clientId` : Consumer Key
     - `secret` : Consumer secret
+    - `repoMaxAge`: Number of minutes list of repositories should be cached, defaults to 480
+    - `userMaxAge`: Number of minutes user information should be cached, defaults to 720
+    - `teamMaxAge`: Number of minutes list of teams should be cached, defaults to 720
 4. Save.
 
 ## Usage

--- a/bitbucket/core.js
+++ b/bitbucket/core.js
@@ -9,8 +9,8 @@ const issueService = require('./issueService');
 const forkService = require('./forkService');
 const pipelineService = require('./pipelineService');
 
-const fetch = (url, token, sort, query = '') => {
-    return alfy.fetch(url(bitbucketUrl), fetchOptions(token, query, sort));
+const fetch = ({ url, token, maxAge, sort, query }) => {
+    return alfy.fetch(url(bitbucketUrl), fetchOptions({ token, maxAge, query, sort }));
 };
 
 module.exports = {

--- a/bitbucket/core.js
+++ b/bitbucket/core.js
@@ -7,9 +7,10 @@ const repoService = require('./repoService');
 const prService = require('./prService');
 const issueService = require('./issueService');
 const forkService = require('./forkService');
+const pipelineService = require('./pipelineService');
 
-const fetch = (url, token, query = '') => {
-    return alfy.fetch(url(bitbucketUrl), fetchOptions(token, query));
+const fetch = (url, token, sort, query = '') => {
+    return alfy.fetch(url(bitbucketUrl), fetchOptions(token, query, sort));
 };
 
 module.exports = {
@@ -23,6 +24,7 @@ module.exports = {
             prService: prService(token, fetch),
             issueService: issueService(token, fetch),
             forkService: forkService(token, fetch),
+            pipelineService: pipelineService(token, fetch)
         };
     }
 };

--- a/bitbucket/core.js
+++ b/bitbucket/core.js
@@ -9,8 +9,8 @@ const issueService = require('./issueService');
 const forkService = require('./forkService');
 const pipelineService = require('./pipelineService');
 
-const fetch = ({ url, token, maxAge, sort, query }) => {
-    return alfy.fetch(url(bitbucketUrl), fetchOptions({ token, maxAge, query, sort }));
+const fetch = ({ url, token, maxAge, sort, query, fields }) => {
+    return alfy.fetch(url(bitbucketUrl), fetchOptions({ token, maxAge, query, sort, fields }));
 };
 
 module.exports = {

--- a/bitbucket/forkService.js
+++ b/bitbucket/forkService.js
@@ -10,4 +10,4 @@ const map = ({ name, owner, links }) => ({
     arg: links.html.href
 });
 
-module.exports = createService(url, map);
+module.exports = createService({ url, map });

--- a/bitbucket/issueService.js
+++ b/bitbucket/issueService.js
@@ -10,4 +10,4 @@ const map = ({ title, reporter, _kind, _priority, links }) => ({
     arg: links.html.href
 });
 
-module.exports = createService(url, map);
+module.exports = createService({ url, map });

--- a/bitbucket/pipelineService.js
+++ b/bitbucket/pipelineService.js
@@ -2,31 +2,31 @@ const createService = require('../utils').createService;
 const moment = require('moment');
 
 const url = (host) => {
-	return host + ['repositories', process.env.repo, 'pipelines/'].join('/');
+    return host + ['repositories', process.env.repo, 'pipelines/'].join('/');
 };
 
 const map = ({ build_number, created_on, repository, creator, state }) => {
-	const getTitle = () => {
-		if (state.result && state.result.name === 'FAILED') {
-			return '❌'
-		}
+    const getTitle = () => {
+        if (state.result && state.result.name === 'FAILED') {
+            return '❌'
+        }
 
-		return '✅'
-	};
+        return '✅'
+    };
 
-	const getSubtitle = () => {
-		const createdOn = moment(created_on).fromNow();
+    const getSubtitle = () => {
+        const createdOn = moment(created_on).fromNow();
 
-		return `${creator.display_name} - ${createdOn}`
-	};
+        return `${creator.display_name} - ${createdOn}`
+    };
 
-	const pipelineUrl = `${repository.links.html.href}/addon/pipelines/home#!/results/${build_number}`;
+    const pipelineUrl = `${repository.links.html.href}/addon/pipelines/home#!/results/${build_number}`;
 
-	return {
-		title: getTitle(),
-		subtitle: getSubtitle(),
-		arg: pipelineUrl
-	}
+    return {
+        title: getTitle(),
+        subtitle: getSubtitle(),
+        arg: pipelineUrl
+    }
 };
 
 module.exports = createService({ url, map });

--- a/bitbucket/pipelineService.js
+++ b/bitbucket/pipelineService.js
@@ -1,0 +1,32 @@
+const createService = require('../utils').createService;
+const moment = require('moment');
+
+const url = (host) => {
+	return host + ['repositories', process.env.repo, 'pipelines/'].join('/');
+};
+
+const map = ({ build_number, created_on, repository, creator, state }) => {
+	const getTitle = () => {
+		if (state.result && state.result.name === 'FAILED') {
+			return '❌'
+		}
+
+		return '✅'
+	};
+
+	const getSubtitle = () => {
+		const createdOn = moment(created_on).fromNow();
+
+		return `${creator.display_name} - ${createdOn}`
+	};
+
+	const pipelineUrl = `${repository.links.html.href}/addon/pipelines/home#!/results/${build_number}`;
+
+	return {
+		title: getTitle(),
+		subtitle: getSubtitle(),
+		arg: pipelineUrl
+	}
+};
+
+module.exports = createService(url, map);

--- a/bitbucket/pipelineService.js
+++ b/bitbucket/pipelineService.js
@@ -5,13 +5,16 @@ const url = (host) => {
     return host + ['repositories', process.env.repo, 'pipelines/'].join('/');
 };
 
-const map = ({ build_number, created_on, repository, creator, state }) => {
+const map = ({ build_number, created_on, repository, creator, state, target }) => {
     const getTitle = () => {
+        let emoji = '✅';
+        const commitMessage = target.commit.message;
+
         if (state.result && state.result.name === 'FAILED') {
-            return '❌'
+            emoji = '❌'
         }
 
-        return '✅'
+        return `${emoji}: ${commitMessage}`
     };
 
     const getSubtitle = () => {

--- a/bitbucket/pipelineService.js
+++ b/bitbucket/pipelineService.js
@@ -29,4 +29,4 @@ const map = ({ build_number, created_on, repository, creator, state }) => {
 	}
 };
 
-module.exports = createService(url, map);
+module.exports = createService({ url, map });

--- a/bitbucket/pipelineService.js
+++ b/bitbucket/pipelineService.js
@@ -5,14 +5,22 @@ const url = (host) => {
     return host + ['repositories', process.env.repo, 'pipelines/'].join('/');
 };
 
-const map = ({ build_number, created_on, repository, creator, state, target }) => {
-    const getTitle = () => {
-        let emoji = '✅';
-        const commitMessage = target.commit.message;
+const RESULT_NAME = {
+    FAILED: 'FAILED'
+};
 
-        if (state.result && state.result.name === 'FAILED') {
-            emoji = '❌'
+const map = ({ build_number, created_on, repository, creator, state, target }) => {
+    const getEmoji = state => {
+        if (state.result && state.result.name === RESULT_NAME.FAILED) {
+            return '❌'
         }
+
+        return '✅';
+    };
+
+    const getTitle = () => {
+        const emoji = getEmoji(state);
+        const commitMessage = target.commit.message;
 
         return `${emoji}: ${commitMessage}`
     };

--- a/bitbucket/prService.js
+++ b/bitbucket/prService.js
@@ -28,4 +28,4 @@ const map = ({ title, author, task_count, links, comment_count, state }) => {
     };
 };
 
-module.exports = createService(url, map);
+module.exports = createService({ url, map });

--- a/bitbucket/repoService.js
+++ b/bitbucket/repoService.js
@@ -34,4 +34,4 @@ const sort = (first, second) => {
     return compareDate(first, second);
 };
 
-module.exports = createService(url, map, sort);
+module.exports = createService({ url, map, sort });

--- a/bitbucket/teamService.js
+++ b/bitbucket/teamService.js
@@ -36,4 +36,4 @@ const sort = (first, second) => {
     return compareDate(first, second);
 };
 
-module.exports = createService(url, map, sort);
+module.exports = createService({ url, map, sort });

--- a/bitbucket/userService.js
+++ b/bitbucket/userService.js
@@ -2,4 +2,4 @@ const createService = require('../utils').createService;
 
 const url = host => `${host}user/`;
 
-module.exports = createService(url, item => item);
+module.exports = createService({ url, map: item => item });

--- a/forks.js
+++ b/forks.js
@@ -2,7 +2,7 @@ const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
 authenticate().then(({ forkService }) => {
-    forkService.load(alfy.input).then(({ values })=> {
+    forkService.load({ query: alfy.input }).then(({ values })=> {
         alfy.output(forkService.map(values));
     });
 });

--- a/info.example.plist
+++ b/info.example.plist
@@ -90,6 +90,16 @@
 				<key>vitoclose</key>
 				<false/>
 			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>E965B1F6-D8D6-46AD-9280-DF7FC87C4D2D</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 		</array>
 		<key>42B4F477-0B9C-43A3-BCE1-5084761F1967</key>
 		<array>
@@ -235,6 +245,19 @@
 				<true/>
 			</dict>
 		</array>
+		<key>9A6B6E58-1863-41ED-9D66-F567D52EB2EA</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>CF028DC0-A659-4BA7-92B7-CBABE1B25562</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
+		</array>
 		<key>A057C677-28C2-4919-8FEB-3CB849A25459</key>
 		<array>
 			<dict>
@@ -328,6 +351,19 @@
 				<string></string>
 				<key>vitoclose</key>
 				<true/>
+			</dict>
+		</array>
+		<key>E965B1F6-D8D6-46AD-9280-DF7FC87C4D2D</key>
+		<array>
+			<dict>
+				<key>destinationuid</key>
+				<string>9A6B6E58-1863-41ED-9D66-F567D52EB2EA</string>
+				<key>modifiers</key>
+				<integer>0</integer>
+				<key>modifiersubtext</key>
+				<string></string>
+				<key>vitoclose</key>
+				<false/>
 			</dict>
 		</array>
 		<key>EF0B250A-65D8-4241-933C-B1D04878427F</key>
@@ -775,7 +811,7 @@
 				<key>fixedorder</key>
 				<false/>
 				<key>items</key>
-				<string>[{"title":"Pull requests","arg":"pull-requests","subtitle":"Show pull requests"},{"title":"Issues","arg":"issues","subtitle":"Show issues"},{"title":"Forks","arg":"forks","subtitle":"Show forks"}]</string>
+				<string>[{"title":"Pull requests","arg":"pull-requests","subtitle":"Show pull requests"},{"title":"Issues","arg":"issues","subtitle":"Show issues"},{"title":"Forks","arg":"forks","subtitle":"Show forks"},{"title":"Pipelines","arg":"pipelines","subtitle":"Show pipelines"}]</string>
 				<key>runningsubtext</key>
 				<string></string>
 				<key>subtext</key>
@@ -813,24 +849,6 @@
 		<dict>
 			<key>config</key>
 			<dict>
-				<key>argument</key>
-				<string>{query}</string>
-				<key>variables</key>
-				<dict>
-					<key>action</key>
-					<string>{query}</string>
-				</dict>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.utility.argument</string>
-			<key>uid</key>
-			<string>0A305F9D-3EE6-487D-8776-4227EBCB1DA7</string>
-			<key>version</key>
-			<integer>1</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
 				<key>inputstring</key>
 				<string>{query}</string>
 				<key>matchcasesensitive</key>
@@ -844,6 +862,24 @@
 			<string>alfred.workflow.utility.filter</string>
 			<key>uid</key>
 			<string>68A09335-C86E-4A15-B391-3CCE3642FD26</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>argument</key>
+				<string>{query}</string>
+				<key>variables</key>
+				<dict>
+					<key>action</key>
+					<string>{query}</string>
+				</dict>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.argument</string>
+			<key>uid</key>
+			<string>0A305F9D-3EE6-487D-8776-4227EBCB1DA7</string>
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
@@ -1082,6 +1118,72 @@
 			<key>version</key>
 			<integer>1</integer>
 		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>alfredfiltersresults</key>
+				<false/>
+				<key>alfredfiltersresultsmatchmode</key>
+				<integer>0</integer>
+				<key>argumenttrimmode</key>
+				<integer>0</integer>
+				<key>argumenttype</key>
+				<integer>1</integer>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>keyword</key>
+				<string>pipelines</string>
+				<key>queuedelaycustom</key>
+				<integer>3</integer>
+				<key>queuedelayimmediatelyinitially</key>
+				<true/>
+				<key>queuedelaymode</key>
+				<integer>0</integer>
+				<key>queuemode</key>
+				<integer>1</integer>
+				<key>runningsubtext</key>
+				<string>Looking for pipelines in {var:repo}</string>
+				<key>script</key>
+				<string>./node_modules/.bin/run-node pipelines.js "$1"</string>
+				<key>scriptargtype</key>
+				<integer>1</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>subtext</key>
+				<string></string>
+				<key>title</key>
+				<string>Looking for pipelines</string>
+				<key>type</key>
+				<integer>0</integer>
+				<key>withspace</key>
+				<true/>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.input.scriptfilter</string>
+			<key>uid</key>
+			<string>9A6B6E58-1863-41ED-9D66-F567D52EB2EA</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>inputstring</key>
+				<string>{var:spec}</string>
+				<key>matchcasesensitive</key>
+				<false/>
+				<key>matchmode</key>
+				<integer>0</integer>
+				<key>matchstring</key>
+				<string>pipelines</string>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.utility.filter</string>
+			<key>uid</key>
+			<string>E965B1F6-D8D6-46AD-9280-DF7FC87C4D2D</string>
+			<key>version</key>
+			<integer>1</integer>
+		</dict>
 	</array>
 	<key>readme</key>
 	<string></string>
@@ -1122,7 +1224,7 @@
 			<key>note</key>
 			<string>Action selected</string>
 			<key>xpos</key>
-			<integer>1050</integer>
+			<integer>1030</integer>
 			<key>ypos</key>
 			<integer>800</integer>
 		</dict>
@@ -1206,6 +1308,13 @@
 			<key>ypos</key>
 			<integer>500</integer>
 		</dict>
+		<key>9A6B6E58-1863-41ED-9D66-F567D52EB2EA</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1230</integer>
+			<key>ypos</key>
+			<integer>990</integer>
+		</dict>
 		<key>A057C677-28C2-4919-8FEB-3CB849A25459</key>
 		<dict>
 			<key>note</key>
@@ -1263,6 +1372,13 @@
 			<key>ypos</key>
 			<integer>10</integer>
 		</dict>
+		<key>E965B1F6-D8D6-46AD-9280-DF7FC87C4D2D</key>
+		<dict>
+			<key>xpos</key>
+			<integer>1140</integer>
+			<key>ypos</key>
+			<integer>1020</integer>
+		</dict>
 		<key>EF0B250A-65D8-4241-933C-B1D04878427F</key>
 		<dict>
 			<key>xpos</key>
@@ -1300,7 +1416,13 @@
 	<dict>
 		<key>clientId</key>
 		<string></string>
+		<key>repoMaxAge</key>
+		<string></string>
 		<key>secret</key>
+		<string></string>
+		<key>teamMaxAge</key>
+		<string></string>
+		<key>userMaxAge</key>
 		<string></string>
 	</dict>
 	<key>variablesdontexport</key>

--- a/issues.js
+++ b/issues.js
@@ -2,7 +2,7 @@ const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
 authenticate().then(({ issueService }) => {
-    issueService.load(alfy.input).then(({ values })=> {
+    issueService.load({ query: alfy.input }).then(({ values })=> {
         alfy.output(issueService.map(values));
     });
 });

--- a/pipelines.js
+++ b/pipelines.js
@@ -2,7 +2,10 @@ const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
 authenticate().then(({ pipelineService }) => {
-	pipelineService.load(alfy.input, '-created_on').then(({ values })=> {
+	pipelineService.load({
+		query: alfy.input,
+		sort: '-created_on'
+	}).then(({ values })=> {
 		alfy.output(pipelineService.map(values));
 	});
 });

--- a/pipelines.js
+++ b/pipelines.js
@@ -1,0 +1,8 @@
+const alfy = require('alfy');
+const authenticate = require('./authenticate.js');
+
+authenticate().then(({ pipelineService }) => {
+	pipelineService.load(alfy.input, '-created_on').then(({ values })=> {
+		alfy.output(pipelineService.map(values));
+	});
+});

--- a/pipelines.js
+++ b/pipelines.js
@@ -2,10 +2,10 @@ const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
 authenticate().then(({ pipelineService }) => {
-	pipelineService.load({
-		query: alfy.input,
-		sort: '-created_on'
-	}).then(({ values })=> {
-		alfy.output(pipelineService.map(values));
-	});
+    pipelineService.load({
+        query: alfy.input,
+        sort: '-created_on'
+    }).then(({ values })=> {
+        alfy.output(pipelineService.map(values));
+    });
 });

--- a/pipelines.js
+++ b/pipelines.js
@@ -4,7 +4,8 @@ const authenticate = require('./authenticate.js');
 authenticate().then(({ pipelineService }) => {
     pipelineService.load({
         query: alfy.input,
-        sort: '-created_on'
+        sort: '-created_on',
+        fields: '+values.target.commit.message'
     }).then(({ values })=> {
         alfy.output(pipelineService.map(values));
     });

--- a/repos.js
+++ b/repos.js
@@ -1,8 +1,8 @@
 const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
-// Eight hours.
-const maxAgeInMinutes = process.env.repoMaxAge || 480;
+const EIGHT_HOURS_MINUTES = 480;
+const maxAgeInMinutes = process.env.repoMaxAge || EIGHT_HOURS_MINUTES;
 
 authenticate().then(({ repoService }) => {
     repoService.load({ query: alfy.input, maxAge: maxAgeInMinutes }).then(({ values })=> {

--- a/repos.js
+++ b/repos.js
@@ -1,8 +1,11 @@
 const alfy = require('alfy');
 const authenticate = require('./authenticate.js');
 
+// Eight hours.
+const maxAgeInMinutes = process.env.repoMaxAge || 480;
+
 authenticate().then(({ repoService }) => {
-    repoService.load(alfy.input).then(({ values })=> {
+    repoService.load({ query: alfy.input, maxAge: maxAgeInMinutes }).then(({ values })=> {
         alfy.output(repoService.output(values));
     });
 });

--- a/teams.js
+++ b/teams.js
@@ -3,9 +3,9 @@ const authenticate = require('./authenticate.js');
 
 const teams = [{ title: '✨Bookmarks', subtitle: 'bookmarks', arg: 'bookmarks' }];
 
-// 12 hours.
-const userMaxAge = process.env.userMaxAge || 720;
-const teamMaxAge = process.env.teamMaxAge || 720;
+const TWELVE_HOURS_MINUTES = 720;
+const userMaxAge = process.env.userMaxAge || TWELVE_HOURS_MINUTES;
+const teamMaxAge = process.env.teamMaxAge || TWELVE_HOURS_MINUTES;
 
 authenticate().then(({ teamService, userService }) => {
     userService.load({ maxAge: userMaxAge }).then((result) => {

--- a/teams.js
+++ b/teams.js
@@ -3,10 +3,14 @@ const authenticate = require('./authenticate.js');
 
 const teams = [{ title: '✨Bookmarks', subtitle: 'bookmarks', arg: 'bookmarks' }];
 
+// 12 hours.
+const userMaxAge = process.env.userMaxAge || 720;
+const teamMaxAge = process.env.teamMaxAge || 720;
+
 authenticate().then(({ teamService, userService }) => {
-    userService.load().then((result) => {
+    userService.load({ maxAge: userMaxAge }).then((result) => {
         let users = [result];
-        teamService.load().then(({ values }) => {
+        teamService.load({ maxAge: teamMaxAge }).then(({ values }) => {
             users = teams.concat(teamService.output(users.concat(values)));
             alfy.output(alfy.inputMatches(users, 'title'));
         });

--- a/utils.js
+++ b/utils.js
@@ -1,20 +1,20 @@
 const moment = require('moment');
 
-const fetchOptions = (token, query = '') => ({
+const fetchOptions = (token, query = '', sort = '-updated_on') => ({
     headers: {
         Authorization: `Bearer ${token}`
     },
     method: 'GET',
     query: {
         q: (query) ? `name~"${query}"` : '',
-        sort: '-updated_on',
+        sort,
         role: 'member'
     }
 });
 
-const createService = (url, map, sort = null) => ((token, fetch) => ({
-    load(query) {
-        return fetch(url, token, query);
+const createService = (url, map, load, sort = null) => ((token, fetch) => ({
+    load(query, sort) {
+        return fetch(url, token, sort, query);
     },
     map(values) {
         return values.map(map);

--- a/utils.js
+++ b/utils.js
@@ -1,25 +1,32 @@
+const alfy = require('alfy');
 const moment = require('moment');
 
-const fetchOptions = ({ token, query, maxAge = 0, sort = '-updated_on' }) => {
+const fetchOptions = ({ token, query, maxAge = 0, sort = '-updated_on', fields }) => {
     const maxAgeMillis = maxAge * 60 * 1000;
+
+    const queryOptions = {
+        q: (query) ? `name~"${query}"` : '',
+        sort,
+        role: 'member'
+    };
+
+    if (fields) {
+        queryOptions.fields = fields;
+    }
 
     return {
         headers: {
             Authorization: `Bearer ${token}`
         },
         method: 'GET',
-        query: {
-            q: (query) ? `name~"${query}"` : '',
-            sort,
-            role: 'member'
-        },
+        query: queryOptions,
         maxAge: maxAgeMillis
     }
 };
 
 const createService = ({ url, map, sort }) => ((token, fetch) => ({
-    load({ query, maxAge, sort }) {
-        return fetch({ url, token, maxAge, sort, query });
+    load({ query, maxAge, sort, fields }) {
+        return fetch({ url, token, maxAge, sort, query, fields });
     },
     map(values) {
         return values.map(map);

--- a/utils.js
+++ b/utils.js
@@ -1,20 +1,25 @@
 const moment = require('moment');
 
-const fetchOptions = (token, query = '', sort = '-updated_on') => ({
-    headers: {
-        Authorization: `Bearer ${token}`
-    },
-    method: 'GET',
-    query: {
-        q: (query) ? `name~"${query}"` : '',
-        sort,
-        role: 'member'
-    }
-});
+const fetchOptions = ({ token, query, maxAge = 0, sort = '-updated_on' }) => {
+    const maxAgeMillis = maxAge * 60 * 1000;
 
-const createService = (url, map, load, sort = null) => ((token, fetch) => ({
-    load(query, sort) {
-        return fetch(url, token, sort, query);
+    return {
+        headers: {
+            Authorization: `Bearer ${token}`
+        },
+        method: 'GET',
+        query: {
+            q: (query) ? `name~"${query}"` : '',
+            sort,
+            role: 'member'
+        },
+        maxAge: maxAgeMillis
+    }
+};
+
+const createService = ({ url, map, sort }) => ((token, fetch) => ({
+    load({ query, maxAge, sort }) {
+        return fetch({ url, token, maxAge, sort, query });
     },
     map(values) {
         return values.map(map);


### PR DESCRIPTION
Hey everyone,

this PR adds support for [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines) and simple caching as suggested in #18.

## What can you do now?

Now, when viewing a repository you can select "Pipelines" and it will show you the ten most recent pipelines that were ran. This is how it looks like.

![Select Menu](http://screenshots.jonas.re/C0JSiNUOI8.png)
![Pipelines](http://screenshots.jonas.re/6hczlazkdQ.png)

It gives you three information:
* Was the pipeline ran successfully or not and the corresponding commit message
* The name of the person that started the pipeline (usually the one who committed)
* When the pipeline was ran, using moment

When you hit enter on the pipeline, it will open the pipeline's page in your browser.

## Things I did to achieve this

* The `load`, `fetch`, `fetchOptions` and `createService` now accept an object because there were just too many arguments and it was confusing in which order they should be. Hope that's okay.
* Created a `pipeline.js` and `pipelineService.js` and connected them in the Alfred UI
* I am not too sure about the check in `pipelineService.js` to show whether the pipeline failed or not. It seemed like the best way. Like this, it matches the behaviour of the Bitbucket UI.

## Questions

* Should we update the gif in the README.md?

Looking forward to your feedback!