### PR TITLE
1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "alfred-bitbucket",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "description": "Workflow to get through your and your teams public / private repositories using App passwords",
     "keywords": [
         "alfred",

--- a/utils.js
+++ b/utils.js
@@ -16,7 +16,7 @@ const fetchOptions = ({ token, query, maxAge = 0, sort = '-updated_on', fields }
 
     return {
         headers: {
-            Authorization: `Bearer ${token}`
+            Authorization: token
         },
         method: 'GET',
         query: queryOptions,


### PR DESCRIPTION
Fixes an issues caused by prepending Bearer in the header causing basic tokens to be `Bearer Basic ${token}`